### PR TITLE
뷰어페이지 SSR 개선

### DIFF
--- a/frontend/apis/bookApi.ts
+++ b/frontend/apis/bookApi.ts
@@ -52,10 +52,20 @@ export const getOrderedBookListApi = async (order: string) => {
   return response.data;
 };
 
-export const getBookApi = async (bookId: string) => {
+/* eslint-disable camelcase */
+export const getBookApi = async (bookId: string, access_token?: string) => {
   const url = `/api/books/${bookId}`;
 
-  const response = await api({ url, method: 'GET' });
+  let response;
+  if (!access_token) response = await api({ url, method: 'GET' });
+  else
+    response = await api({
+      url,
+      method: 'GET',
+      header: {
+        Cookie: `access_token=${access_token};`,
+      },
+    });
 
   return response.data;
 };

--- a/frontend/components/common/Modal/styled.ts
+++ b/frontend/components/common/Modal/styled.ts
@@ -7,6 +7,7 @@ export const Dimmed = styled.div`
   width: 100vw;
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.3);
+  z-index: 98;
 `;
 
 export const ModalWrapper = styled.div`
@@ -14,7 +15,7 @@ export const ModalWrapper = styled.div`
   top: 0px;
   left: 0px;
   width: 100%;
-  height: 100%;
+  height: var(--window-inner-height);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/frontend/pages/viewer/[...data].tsx
+++ b/frontend/pages/viewer/[...data].tsx
@@ -7,7 +7,6 @@ import { useEffect, useState } from 'react';
 import { getArticleApi } from '@apis/articleApi';
 import { getBookApi } from '@apis/bookApi';
 import GNB from '@components/common/GNB';
-import ScrollAppearer from '@components/common/ScrollAppearer';
 import ArticleContainer from '@components/viewer/ArticleContent';
 import TOC from '@components/viewer/TOC';
 import ViewerHead from '@components/viewer/ViewerHead';
@@ -66,10 +65,8 @@ export default function Viewer({ article, book }: ViewerProps) {
   return (
     <PageNoScrollWrapper>
       {article && <ViewerHead articleTitle={article.title} articleContent={article.content} />}
-      <PageGNBHide>
-        <ScrollAppearer height="67px" isScrollDown={isScrollDown === 'true'}>
-          <GNB />
-        </ScrollAppearer>
+      <PageGNBHide isscrolldown={isScrollDown}>
+        <GNB />
       </PageGNBHide>
       {book && article && (
         <Flex>

--- a/frontend/pages/viewer/[...data].tsx
+++ b/frontend/pages/viewer/[...data].tsx
@@ -11,22 +11,20 @@ import ScrollAppearer from '@components/common/ScrollAppearer';
 import ArticleContainer from '@components/viewer/ArticleContent';
 import TOC from '@components/viewer/TOC';
 import ViewerHead from '@components/viewer/ViewerHead';
-import useFetch from '@hooks/useFetch';
 import { IArticleBook, IBookScraps } from '@interfaces';
 import { Flex, PageGNBHide, PageNoScrollWrapper } from '@styles/layout';
 import { parseHeadings } from '@utils/toc';
 
 interface ViewerProps {
   article: IArticleBook;
+  book: IBookScraps;
 }
 
-export default function Viewer({ article }: ViewerProps) {
+export default function Viewer({ article, book }: ViewerProps) {
   const Modal = dynamic(() => import('@components/common/Modal'));
   const ScrapModal = dynamic(() => import('@components/viewer/ScrapModal'));
 
   const router = useRouter();
-
-  const { data: book, execute: getBook } = useFetch<IBookScraps>(getBookApi);
 
   const [isSideBarOpen, setSideBarOpen] = useState(false);
   const [isModalShown, setModalShown] = useState(false);
@@ -57,13 +55,6 @@ export default function Viewer({ article }: ViewerProps) {
 
     return () => window.removeEventListener('resize', syncHeight);
   }, []);
-
-  useEffect(() => {
-    if (Array.isArray(router.query.data) && router.query.data?.length === 2) {
-      const bookId = router.query.data[0];
-      getBook(bookId);
-    }
-  }, [router.query.data]);
 
   useEffect(() => {
     if (book === undefined) return;
@@ -113,9 +104,12 @@ export default function Viewer({ article }: ViewerProps) {
   );
 }
 
+/* eslint-disable camelcase */
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const [, articleId] = context.query.data as string[];
+  const [bookId, articleId] = context.query.data as string[];
+  const { cookies } = context.req;
   const article = await getArticleApi(articleId);
+  const book = await getBookApi(bookId, cookies.access_token);
 
-  return { props: { article } };
+  return { props: { article, book } };
 };

--- a/frontend/styles/layout.ts
+++ b/frontend/styles/layout.ts
@@ -64,8 +64,10 @@ export const PageNoScrollWrapper = styled.div`
   width: 100%;
 `;
 
-export const PageGNBHide = styled.div`
+export const PageGNBHide = styled.div<{ isscrolldown: 'true' | 'false' }>`
   position: absolute;
+  top: ${(props) => (props.isscrolldown === 'true' ? '-67px' : '0px')};
+  transition: top 0.2s ease-in-out;
   width: 100%;
 `;
 


### PR DESCRIPTION
## 개요

뷰어페이지 SSR을 개선하였습니다.

## 변경 사항

- 이전에는 뷰어페이지의 article 데이터만 SSR로 받아오고 있었는데, 렌더링 시 book 데이터도 있어야 article 내용도 렌더링되도록 되어 있었기 때문에 결과적으로는 아티클 데이터도 초기에 렌더링되지 않는 상황이었습니다.
- book 데이터를 받아올 때 토큰이 필요했기 때문에 Next.js 서버 측에서 context.req.cookies 로부터 토큰을 가져와 요청을 보내 받아오는 것으로 변경하였습니다.
- 뷰어페이지에서 ScrollAppearer를 적용했을 때 모달이 표시되지 않는 버그가 있어, 이전 상태로 수정하였습니다.

## 스크린샷

아래와 같이 자바스크립트를 차단하더라도 글 내용을 볼 수 있게 되었습니다.

<img width="958" alt="image" src="https://user-images.githubusercontent.com/109179856/213848893-e4c54bc0-bd83-4af9-a88d-a61ea5c8d616.png">


## 관련 이슈

- #12 
